### PR TITLE
Remove jsonify dependency, add a `stringify` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-var json = typeof JSON !== 'undefined' ? JSON : require('jsonify');
-
 module.exports = function (obj, opts) {
     if (!opts) opts = {};
     if (typeof opts === 'function') opts = { cmp: opts };
@@ -7,6 +5,7 @@ module.exports = function (obj, opts) {
     if (typeof space === 'number') space = Array(space+1).join(' ');
     var cycles = (typeof opts.cycles === 'boolean') ? opts.cycles : false;
     var replacer = opts.replacer || function(key, value) { return value; };
+    var jsonStringify = opts.stringify || JSON.stringify;
 
     var cmp = opts.cmp && (function (f) {
         return function (node) {
@@ -33,19 +32,19 @@ module.exports = function (obj, opts) {
             return;
         }
         if (typeof node !== 'object' || node === null) {
-            return json.stringify(node);
+            return jsonStringify(node);
         }
         if (isArray(node)) {
             var out = [];
             for (var i = 0; i < node.length; i++) {
-                var item = stringify(node, i, node[i], level+1) || json.stringify(null);
+                var item = stringify(node, i, node[i], level+1) || jsonStringify(null);
                 out.push(indent + space + item);
             }
             return '[' + out.join(',') + indent + ']';
         }
         else {
             if (seen.indexOf(node) !== -1) {
-                if (cycles) return json.stringify('__cycle__');
+                if (cycles) return jsonStringify('__cycle__');
                 throw new TypeError('Converting circular structure to JSON');
             }
             else seen.push(node);
@@ -58,7 +57,7 @@ module.exports = function (obj, opts) {
 
                 if(!value) continue;
 
-                var keyValue = json.stringify(key)
+                var keyValue = jsonStringify(key)
                     + colonSeparator
                     + value;
                 ;
@@ -81,3 +80,4 @@ var objectKeys = Object.keys || function (obj) {
     }
     return keys;
 };
+

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "version": "1.0.0",
   "description": "deterministic JSON.stringify() with custom sorting to get deterministic hashes from stringified results",
   "main": "index.js",
-  "dependencies": {
-    "jsonify": "~0.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "tape": "~1.0.4"
   },

--- a/readme.markdown
+++ b/readme.markdown
@@ -117,6 +117,10 @@ The replacer parameter is a function `opts.replacer(key, value)` that behaves
 the same as the replacer
 [from the core JSON object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_native_JSON#The_replacer_parameter).
 
+### stringify
+
+Defaults to `JSON.stringify`.  This is the function that is used to stringify the individual atoms (Strings, Keys, Numbers etc.)
+
 # install
 
 With [npm](https://npmjs.org) do:


### PR DESCRIPTION
 The `stringify` option can be provided by users who wish to polyfill

This is a breaking change as it will break support for browser that don’t have a built in JSON implementation.
