### PR TITLE
Support numeric zero as value of the space parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ module.exports = function (obj, opts) {
     if (typeof opts === 'function') opts = { cmp: opts };
     var space = opts.space || '';
     if (typeof space === 'number') space = Array(space+1).join(' ');
+    var input_space = opts.space;
     var cycles = (typeof opts.cycles === 'boolean') ? opts.cycles : false;
     var replacer = opts.replacer || function(key, value) { return value; };
 
@@ -20,7 +21,13 @@ module.exports = function (obj, opts) {
 
     var seen = [];
     return (function stringify (parent, key, node, level) {
-        var indent = space ? ('\n' + new Array(level + 1).join(space)) : '';
+        if (input_space === 0) {
+            var indent = '\n';
+        } else if (input_space) {
+            var indent = ('\n' + new Array(level + 1).join(space));
+        } else {
+            var indent = '';
+        }
         var colonSeparator = space ? ': ' : ':';
 
         if (node && node.toJSON && typeof node.toJSON === 'function') {

--- a/test/space.js
+++ b/test/space.js
@@ -34,6 +34,17 @@ test('space parameter (with a number)', function (t) {
     );
 });
 
+test('space parameter (with a numeric zero)', function (t) {
+    t.plan(1);
+    var obj = { one: 1, two: 2 };
+    t.equal(stringify(obj, {space: 0}), ''
+        + '{\n'
+        + '"one":1,\n'
+        + '"two":2\n'
+        + '}'
+    );
+});
+
 test('space parameter (nested objects)', function (t) {
     t.plan(1);
     var obj = { one: 1, two: { b: 4, a: [2,3] } };


### PR DESCRIPTION
Support numeric zero as value of the space parameter, which results in line breaks without indentation.

The motivation is storing many similar big JSON files in diffed form. This is achieved by running unix diff on the JSON; in our tests this has been more efficient than binary diff. 

json-stable-stringify already gets us most of the way there, but indentation inflates file size tremendously. This PR allows placing line breaks but not indentation symbols, which solves the problem.