### PR TITLE
terseEmptyLiterals param

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ module.exports = function (obj, opts) {
     if (!opts) opts = {};
     if (typeof opts === 'function') opts = { cmp: opts };
     var space = opts.space || '';
+    var terseEmptyLiterals = opts.terseEmptyLiterals || false;
     if (typeof space === 'number') space = Array(space+1).join(' ');
     var cycles = (typeof opts.cycles === 'boolean') ? opts.cycles : false;
     var replacer = opts.replacer || function(key, value) { return value; };
@@ -41,7 +42,10 @@ module.exports = function (obj, opts) {
                 var item = stringify(node, i, node[i], level+1) || json.stringify(null);
                 out.push(indent + space + item);
             }
-            return '[' + out.join(',') + indent + ']';
+            return '['
+                + out.join(',')
+                + ((terseEmptyLiterals && out.length === 0) ? '' : indent)
+                + ']';
         }
         else {
             if (seen.indexOf(node) !== -1) {
@@ -65,7 +69,10 @@ module.exports = function (obj, opts) {
                 out.push(indent + space + keyValue);
             }
             seen.splice(seen.indexOf(node), 1);
-            return '{' + out.join(',') + indent + '}';
+            return '{'
+                + out.join(',')
+                + ((terseEmptyLiterals && out.length === 0) ? '' : indent)
+                + '}';
         }
     })({ '': obj }, '', obj, 0);
 };

--- a/test/space.js
+++ b/test/space.js
@@ -51,6 +51,29 @@ test('space parameter (nested objects)', function (t) {
     );
 });
 
+test('space parameter (empty nested objects)', function (t) {
+    t.plan(1);
+    var obj = { one: 1, two: {} };
+    t.equal(stringify(obj, {space: '  '}), ''
+        + '{\n'
+        + '  "one": 1,\n'
+        + '  "two": {\n'
+        + '  }\n'
+        + '}'
+    );
+});
+
+test('terseEmptyLiterals parameter', function (t) {
+    t.plan(1);
+    var obj = { one: 1, two: {} };
+    t.equal(stringify(obj, {space: '  ', terseEmptyLiterals: true}), ''
+        + '{\n'
+        + '  "one": 1,\n'
+        + '  "two": {}\n'
+        + '}'
+    );
+});
+
 test('space parameter (same as native)', function (t) {
     t.plan(1);
     // for this test, properties need to be in alphabetical order


### PR DESCRIPTION
When using the `space` param, empty object/array literals are rendered in a slightly unorthodox manner

```
{
  "a": [
  ]
}
```

This new param allows rendering them inline (and in my opinion, more naturally)

```
{
  "a": []
}
```

The parameter defaults to false for backwards compatibility