### PR TITLE
Native spacing for empty objects and arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = function (obj, opts) {
                 var item = stringify(node, i, node[i], level+1) || json.stringify(null);
                 out.push(indent + space + item);
             }
-            return '[' + out.join(',') + indent + ']';
+            return '[' + out.join(',') + (out.length ? indent : '') + ']';
         }
         else {
             if (seen.indexOf(node) !== -1) {
@@ -65,7 +65,7 @@ module.exports = function (obj, opts) {
                 out.push(indent + space + keyValue);
             }
             seen.splice(seen.indexOf(node), 1);
-            return '{' + out.join(',') + indent + '}';
+            return '{' + out.join(',') + (out.length ? indent : '') + '}';
         }
     })({ '': obj }, '', obj, 0);
 };

--- a/test/space.js
+++ b/test/space.js
@@ -57,3 +57,10 @@ test('space parameter (same as native)', function (t) {
     var obj = { one: 1, two: { a: [2,3], b: 4 } };
     t.equal(stringify(obj, {space: '  '}), JSON.stringify(obj, null, '  '));
 });
+
+test('space parameter (same as native for empty objects and arrays)', function (t) {
+    t.plan(1);
+    // for this test, properties need to be in alphabetical order
+    var obj = { one: 1, two: { a: [2,3], b: 4, c: [], d: {} } };
+    t.equal(stringify(obj, {space: '  '}), JSON.stringify(obj, null, '  '));
+});


### PR DESCRIPTION
Make the spacing native for empty objects and empty arrays.

```js
jsonStable([], { space: '  ' }) // before => "[\n]" -- after => "[]"
jsonStable([], { space: '  ' }) // before => "{\n}" -- after => "{}"
```